### PR TITLE
Remove micromamba run wrapper

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/Dockerfile
@@ -11,4 +11,4 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER . /app
 
 EXPOSE 8000 5678
 
-CMD ["micromamba", "run", "-n", "base", "python", "app/main.py"]
+CMD ["python", "app/main.py"]

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build:
       context: backend
       dockerfile: Dockerfile
-    command: micromamba run -n base celery --app app.tasks worker --loglevel=DEBUG -Q main-queue -c 1
+    command: celery --app app.tasks worker --loglevel=DEBUG -Q main-queue -c 1
 
   flower:  
     image: mher/flower
@@ -44,7 +44,7 @@ services:
     build:
       context: backend
       dockerfile: Dockerfile
-    command: micromamba run -n base python app/main.py
+    command: python app/main.py
     tty: true
     volumes:
       - ./backend:/app/:cached


### PR DESCRIPTION
## Summary
- invoke app directly in Docker CMD without micromamba run
- drop micromamba wrapper from backend and worker commands in docker-compose

## Testing
- `docker compose config` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae17ae7c88321927d0fff57ab3ce1